### PR TITLE
chore: rename confio to cosmos

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/confio/ics23/go
+module github.com/cosmos/ics23/go
 
 go 1.19
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,44 +1,44 @@
 [package]
-name = "ics23"
-version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+description = "Merkle proof verification library - implements Cosmos ICS23 Spec"
 edition = "2021"
 exclude = ["codegen", "no-std-check"]
-description = "Merkle proof verification library - implements Cosmos ICS23 Spec"
-repository = "https://github.com/confio/ics23/tree/master/rust"
 license = "Apache-2.0"
+name = "ics23"
+repository = "https://github.com/cosmos/ics23/tree/master/rust"
 rust-version = "1.56.1"
+version = "0.8.1"
 
 [workspace]
 members = ["codegen", "no-std-check"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
-bytes = { version = "1.0.1", default-features = false }
-hex = { version = "0.4.3", default-features = false, features = [ "alloc" ] }
-anyhow = { version = "1.0.40", default-features = false }
-sha2 = { version = "0.10.2", optional = true, default-features = false }
-sha3 = { version = "0.10.2", optional = true, default-features = false }
-ripemd = { version = "0.1.1", optional = true, default-features = false }
+anyhow = {version = "1.0.40", default-features = false}
+bytes = {version = "1.0.1", default-features = false}
+hex = {version = "0.4.3", default-features = false, features = ["alloc"]}
+prost = {version = "0.11", default-features = false, features = ["prost-derive"]}
+ripemd = {version = "0.1.1", optional = true, default-features = false}
+sha2 = {version = "0.10.2", optional = true, default-features = false}
+sha3 = {version = "0.10.2", optional = true, default-features = false}
 
 [dev-dependencies]
-sha2 = { version = "0.10.2" }
-sha3 = { version = "0.10.2" }
-ripemd = { version = "0.1.1" }
-serde = { version = "1.0.125", features = ["derive"] }
-serde_json = { version = "1.0.64" }
+ripemd = {version = "0.1.1"}
+serde = {version = "1.0.125", features = ["derive"]}
+serde_json = {version = "1.0.64"}
+sha2 = {version = "0.10.2"}
+sha3 = {version = "0.10.2"}
 
 [features]
 default = ["std", "host-functions"]
-std = [
-    "prost/std",
-    "bytes/std",
-    "hex/std",
-    "anyhow/std",
-]
 host-functions = [
-    "sha2",
-    "sha3",
-    "ripemd",
+  "sha2",
+  "sha3",
+  "ripemd",
+]
+std = [
+  "prost/std",
+  "bytes/std",
+  "hex/std",
+  "anyhow/std",
 ]


### PR DESCRIPTION
this in preparation for 0.47 release. 

I have created a release/v0.9.x branch that has the changes for the pre 0.47 lines 