### PR TITLE
chore: retract previous versions

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -6,3 +6,6 @@ require (
 	github.com/cosmos/gogoproto v1.4.3
 	golang.org/x/crypto v0.2.0
 )
+
+// subject to the dragonberry vulnerability
+retract [v0.0.0, v0.7.0]


### PR DESCRIPTION
Closes #125

This will be enforced at next ICS23 tag.