### PR TITLE
feat: support BLAKE3 cryptographic hash function 

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ prost = {version = "0.11", default-features = false, features = ["prost-derive"]
 ripemd = {version = "0.1.1", optional = true, default-features = false}
 sha2 = {version = "0.10.2", optional = true, default-features = false}
 sha3 = {version = "0.10.2", optional = true, default-features = false}
+blake3 = {version = "1.3.3", default-features = false}
 
 [dev-dependencies]
 ripemd = {version = "0.1.1"}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,10 +4,10 @@ description = "Merkle proof verification library - implements Cosmos ICS23 Spec"
 edition = "2021"
 exclude = ["codegen", "no-std-check"]
 license = "Apache-2.0"
-name = "ics23"
-repository = "https://github.com/cosmos/ics23/tree/master/rust"
+name = "ics23-blake3"
+repository = "https://github.com/shuimuliang/ics23"
 rust-version = "1.56.1"
-version = "0.9.0"
+version = "0.9.1"
 
 [workspace]
 members = ["codegen", "no-std-check"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,8 +4,8 @@ description = "Merkle proof verification library - implements Cosmos ICS23 Spec"
 edition = "2021"
 exclude = ["codegen", "no-std-check"]
 license = "Apache-2.0"
-name = "ics23-blake3"
-repository = "https://github.com/shuimuliang/ics23"
+name = "ics23"
+repository = "https://github.com/cosmos/ics23/tree/master/rust"
 rust-version = "1.56.1"
 version = "0.9.1"
 

--- a/rust/no-std-check/Cargo.toml
+++ b/rust/no-std-check/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-ics23-blake3 = { path = "../", default-features = false }
+ics23 = { path = "../", default-features = false }
 
 [features]
 panic-handler = []

--- a/rust/no-std-check/Cargo.toml
+++ b/rust/no-std-check/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-ics23 = { path = "../", default-features = false }
+ics23-blake3 = { path = "../", default-features = false }
 
 [features]
 panic-handler = []

--- a/rust/src/cosmos.ics23.v1.rs
+++ b/rust/src/cosmos.ics23.v1.rs
@@ -258,7 +258,6 @@ pub struct CompressedNonExistenceProof {
     #[prost(message, optional, tag = "3")]
     pub right: ::core::option::Option<CompressedExistenceProof>,
 }
-#[derive(Eq)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum HashOp {
@@ -271,6 +270,7 @@ pub enum HashOp {
     /// ripemd160(sha256(x))
     Bitcoin = 5,
     Sha512256 = 6,
+    Blake3 = 7,
 }
 impl HashOp {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -286,6 +286,7 @@ impl HashOp {
             HashOp::Ripemd160 => "RIPEMD160",
             HashOp::Bitcoin => "BITCOIN",
             HashOp::Sha512256 => "SHA512_256",
+            HashOp::Blake3 => "Blake3"
         }
     }
 }
@@ -294,7 +295,6 @@ impl HashOp {
 /// to include length information. After encoding the length with the given
 /// algorithm, the length will be prepended to the key and value bytes.
 /// (Each one with it's own encoded length)
-#[derive(Eq)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum LengthOp {

--- a/rust/src/host_functions.rs
+++ b/rust/src/host_functions.rs
@@ -66,8 +66,8 @@ pub mod host_functions_impl {
         }
 
         fn blake3hash(message: &[u8]) -> [u8; 32] {
-           let hash= blake3::hash(message);
-           *hash.as_bytes()
+            let hash = blake3::hash(message);
+            *hash.as_bytes()
         }
     }
 }

--- a/rust/src/host_functions.rs
+++ b/rust/src/host_functions.rs
@@ -16,6 +16,9 @@ pub trait HostFunctionsProvider {
 
     /// Ripemd160 hash function.
     fn ripemd160(message: &[u8]) -> [u8; 20];
+
+    /// blake3 hash function.
+    fn blake3hash(message: &[u8]) -> [u8; 32];
 }
 
 #[cfg(any(feature = "host-functions", test))]
@@ -60,6 +63,11 @@ pub mod host_functions_impl {
             let mut buf = [0u8; 20];
             buf.copy_from_slice(&digest);
             buf
+        }
+
+        fn blake3hash(message: &[u8]) -> [u8; 32] {
+           let hash= blake3::hash(message);
+           *hash.as_bytes()
         }
     }
 }

--- a/rust/src/ops.rs
+++ b/rust/src/ops.rs
@@ -46,7 +46,7 @@ fn do_hash<H: HostFunctionsProvider>(hash: HashOp, data: &[u8]) -> Hash {
         HashOp::Ripemd160 => Hash::from(H::ripemd160(data)),
         HashOp::Bitcoin => Hash::from(H::ripemd160(&H::sha2_256(data)[..])),
         HashOp::Sha512256 => Hash::from(H::sha2_512_truncated(data)),
-        HashOp::Blake3 => Hash::from(H::blake3hash (data)),
+        HashOp::Blake3 => Hash::from(H::blake3hash(data)),
     }
 }
 
@@ -124,7 +124,7 @@ mod tests {
         );
 
         let hash = do_hash::<HostFunctionsManager>(HashOp::Blake3, b"food");
-        assert!( hash == decode("f775a8ccf8cb78cd1c63ade4e9802de4ead836b36cea35242accf31d2c6a3697"));
+        assert!(hash == decode("f775a8ccf8cb78cd1c63ade4e9802de4ead836b36cea35242accf31d2c6a3697"),);
     }
 
     #[test]
@@ -269,5 +269,4 @@ mod tests {
             "unexpected inner hash"
         );
     }
-
 }

--- a/rust/src/ops.rs
+++ b/rust/src/ops.rs
@@ -124,7 +124,7 @@ mod tests {
         );
 
         let hash = do_hash::<HostFunctionsManager>(HashOp::Blake3, b"food");
-        assert!(hash == decode("f775a8ccf8cb78cd1c63ade4e9802de4ead836b36cea35242accf31d2c6a3697"),);
+        assert!(hash == decode("f775a8ccf8cb78cd1c63ade4e9802de4ead836b36cea35242accf31d2c6a3697"), "blake3 hash fails");
     }
 
     #[test]

--- a/rust/src/ops.rs
+++ b/rust/src/ops.rs
@@ -46,6 +46,7 @@ fn do_hash<H: HostFunctionsProvider>(hash: HashOp, data: &[u8]) -> Hash {
         HashOp::Ripemd160 => Hash::from(H::ripemd160(data)),
         HashOp::Bitcoin => Hash::from(H::ripemd160(&H::sha2_256(data)[..])),
         HashOp::Sha512256 => Hash::from(H::sha2_512_truncated(data)),
+        HashOp::Blake3 => Hash::from(H::blake3hash (data)),
     }
 }
 
@@ -121,6 +122,9 @@ mod tests {
             hash == decode("5b3a452a6acbf1fc1e553a40c501585d5bd3cca176d562e0a0e19a3c43804e88"),
             "sha512/256 hash fails"
         );
+
+        let hash = do_hash::<HostFunctionsManager>(HashOp::Blake3, b"food");
+        assert!( hash == decode("f775a8ccf8cb78cd1c63ade4e9802de4ead836b36cea35242accf31d2c6a3697"));
     }
 
     #[test]
@@ -265,4 +269,5 @@ mod tests {
             "unexpected inner hash"
         );
     }
+
 }


### PR DESCRIPTION
according to the comment:
1. restore Cargo.toml
name = "ics23"
repository = "https://github.com/cosmos/ics23/tree/master/rust"

2. test case fixed in rust/src/ops.rs
`assert!(hash == decode("f775a8ccf8cb78cd1c63ade4e9802de4ead836b36cea35242accf31d2c6a3697"), "blake3 hash fails");`