### PR TITLE
go: compressStep uses num, ok:=map[string(byteslice)]

### DIFF
--- a/go/compress.go
+++ b/go/compress.go
@@ -89,21 +89,19 @@ func compressExist(exist *ExistenceProof, lookup *[]*InnerOp, registry map[strin
 }
 
 func compressStep(step *InnerOp, lookup *[]*InnerOp, registry map[string]int32) int32 {
-	bz, err := step.Marshal()
 	if err != nil {
 		panic(err)
 	}
-	sig := string(bz)
 
 	// load from cache if there
-	if num, ok := registry[sig]; ok {
+        if num, ok := registry[string(bz)]; ok {
 		return num
 	}
 
 	// create new step if not there
 	num := int32(len(*lookup))
 	*lookup = append(*lookup, step)
-	registry[sig] = num
+        registry[string(bz)] = num
 	return num
 }
 


### PR DESCRIPTION
Changed the code  as per the advice 