### PR TITLE
feat: enable no_std support for `pbjson`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ ripemd = {version = "0.1.1", optional = true, default-features = false}
 sha2 = {version = "0.10.2", optional = true, default-features = false}
 sha3 = {version = "0.10.2", optional = true, default-features = false}
 serde = {version = "1.0", optional = true, default-features = false}
-informalsystems-pbjson = { git = "https://github.com/informalsystems/pbjson", rev = "e54f504", optional = true, default-features = false }
+informalsystems-pbjson = { version = "0.6.0", optional = true, default-features = false }
 
 [dev-dependencies]
 ripemd = {version = "0.1.1"}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ ripemd = {version = "0.1.1", optional = true, default-features = false}
 sha2 = {version = "0.10.2", optional = true, default-features = false}
 sha3 = {version = "0.10.2", optional = true, default-features = false}
 serde = {version = "1.0", optional = true, default-features = false}
-informalsystems-pbjson = { git = "https://github.com/informalsystems/pbjson", rev = "e54f504", default-features = false, optional = true }
+informalsystems-pbjson = { git = "https://github.com/informalsystems/pbjson", rev = "e54f504", optional = true, default-features = false }
 
 [dev-dependencies]
 ripemd = {version = "0.1.1"}
@@ -32,10 +32,10 @@ sha2 = {version = "0.10.2"}
 sha3 = {version = "0.10.2"}
 
 [features]
-default = ["std", "host-functions", "serde"]
+default = ["std", "host-functions"]
 
-std = ["prost/std", "bytes/std", "hex/std", "anyhow/std"]
+std = ["prost/std", "bytes/std", "hex/std", "anyhow/std", "informalsystems-pbjson/std", "serde/std"]
 
 host-functions = ["sha2", "sha3", "ripemd"]
 
-serde = ["serde/std", "informalsystems-pbjson/std"]
+serde = ["dep:serde", "informalsystems-pbjson"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ ripemd = {version = "0.1.1", optional = true, default-features = false}
 sha2 = {version = "0.10.2", optional = true, default-features = false}
 sha3 = {version = "0.10.2", optional = true, default-features = false}
 serde = {version = "1.0", optional = true, default-features = false}
-pbjson = {version = "0.5.1", optional = true}
+informalsystems-pbjson = { git = "https://github.com/informalsystems/pbjson", rev = "e54f504", default-features = false, optional = true }
 
 [dev-dependencies]
 ripemd = {version = "0.1.1"}
@@ -38,4 +38,4 @@ std = ["prost/std", "bytes/std", "hex/std", "anyhow/std"]
 
 host-functions = ["sha2", "sha3", "ripemd"]
 
-serde = ["serde/std", "dep:pbjson"]
+serde = ["serde/std", "informalsystems-pbjson/std"]

--- a/rust/codegen/Cargo.toml
+++ b/rust/codegen/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 bytes = "1.0.1"
 prost = "0.11"
 prost-build = "0.11"
-pbjson-build = "0.5.1"
+informalsystems-pbjson-build = { git = "https://github.com/informalsystems/pbjson", rev = "e54f504" }

--- a/rust/codegen/Cargo.toml
+++ b/rust/codegen/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 bytes = "1.0.1"
 prost = "0.11"
 prost-build = "0.11"
-informalsystems-pbjson-build = { git = "https://github.com/informalsystems/pbjson", rev = "e54f504" }
+informalsystems-pbjson-build = "0.6.0"

--- a/rust/src/cosmos.ics23.v1.serde.rs
+++ b/rust/src/cosmos.ics23.v1.serde.rs
@@ -1,6 +1,6 @@
 impl serde::Serialize for BatchEntry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -25,7 +25,7 @@ impl serde::Serialize for BatchEntry {
 }
 impl<'de> serde::Deserialize<'de> for BatchEntry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -40,7 +40,7 @@ impl<'de> serde::Deserialize<'de> for BatchEntry {
             Nonexist,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -49,12 +49,12 @@ impl<'de> serde::Deserialize<'de> for BatchEntry {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -72,11 +72,11 @@ impl<'de> serde::Deserialize<'de> for BatchEntry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BatchEntry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.BatchEntry")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<BatchEntry, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<BatchEntry, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -87,14 +87,14 @@ impl<'de> serde::Deserialize<'de> for BatchEntry {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("exist"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(batch_entry::Proof::Exist)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(batch_entry::Proof::Exist)
 ;
                         }
                         GeneratedField::Nonexist => {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("nonexist"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(batch_entry::Proof::Nonexist)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(batch_entry::Proof::Nonexist)
 ;
                         }
                     }
@@ -109,7 +109,7 @@ impl<'de> serde::Deserialize<'de> for BatchEntry {
 }
 impl serde::Serialize for BatchProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -127,7 +127,7 @@ impl serde::Serialize for BatchProof {
 }
 impl<'de> serde::Deserialize<'de> for BatchProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -140,7 +140,7 @@ impl<'de> serde::Deserialize<'de> for BatchProof {
             Entries,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -149,12 +149,12 @@ impl<'de> serde::Deserialize<'de> for BatchProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -171,11 +171,11 @@ impl<'de> serde::Deserialize<'de> for BatchProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = BatchProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.BatchProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<BatchProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<BatchProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -200,7 +200,7 @@ impl<'de> serde::Deserialize<'de> for BatchProof {
 }
 impl serde::Serialize for CommitmentProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -231,7 +231,7 @@ impl serde::Serialize for CommitmentProof {
 }
 impl<'de> serde::Deserialize<'de> for CommitmentProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -250,7 +250,7 @@ impl<'de> serde::Deserialize<'de> for CommitmentProof {
             Compressed,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -259,12 +259,12 @@ impl<'de> serde::Deserialize<'de> for CommitmentProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -284,11 +284,11 @@ impl<'de> serde::Deserialize<'de> for CommitmentProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CommitmentProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.CommitmentProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<CommitmentProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<CommitmentProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -299,28 +299,28 @@ impl<'de> serde::Deserialize<'de> for CommitmentProof {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("exist"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(commitment_proof::Proof::Exist)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(commitment_proof::Proof::Exist)
 ;
                         }
                         GeneratedField::Nonexist => {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("nonexist"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(commitment_proof::Proof::Nonexist)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(commitment_proof::Proof::Nonexist)
 ;
                         }
                         GeneratedField::Batch => {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("batch"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(commitment_proof::Proof::Batch)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(commitment_proof::Proof::Batch)
 ;
                         }
                         GeneratedField::Compressed => {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("compressed"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(commitment_proof::Proof::Compressed)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(commitment_proof::Proof::Compressed)
 ;
                         }
                     }
@@ -335,7 +335,7 @@ impl<'de> serde::Deserialize<'de> for CommitmentProof {
 }
 impl serde::Serialize for CompressedBatchEntry {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -360,7 +360,7 @@ impl serde::Serialize for CompressedBatchEntry {
 }
 impl<'de> serde::Deserialize<'de> for CompressedBatchEntry {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -375,7 +375,7 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchEntry {
             Nonexist,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -384,12 +384,12 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchEntry {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -407,11 +407,11 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchEntry {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CompressedBatchEntry;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.CompressedBatchEntry")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<CompressedBatchEntry, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<CompressedBatchEntry, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -422,14 +422,14 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchEntry {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("exist"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(compressed_batch_entry::Proof::Exist)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(compressed_batch_entry::Proof::Exist)
 ;
                         }
                         GeneratedField::Nonexist => {
                             if proof__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("nonexist"));
                             }
-                            proof__ = map.next_value::<::std::option::Option<_>>()?.map(compressed_batch_entry::Proof::Nonexist)
+                            proof__ = map.next_value::<::core::option::Option<_>>()?.map(compressed_batch_entry::Proof::Nonexist)
 ;
                         }
                     }
@@ -444,7 +444,7 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchEntry {
 }
 impl serde::Serialize for CompressedBatchProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -468,7 +468,7 @@ impl serde::Serialize for CompressedBatchProof {
 }
 impl<'de> serde::Deserialize<'de> for CompressedBatchProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -484,7 +484,7 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchProof {
             LookupInners,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -493,12 +493,12 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -516,11 +516,11 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CompressedBatchProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.CompressedBatchProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<CompressedBatchProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<CompressedBatchProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -553,7 +553,7 @@ impl<'de> serde::Deserialize<'de> for CompressedBatchProof {
 }
 impl serde::Serialize for CompressedExistenceProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -589,7 +589,7 @@ impl serde::Serialize for CompressedExistenceProof {
 }
 impl<'de> serde::Deserialize<'de> for CompressedExistenceProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -608,7 +608,7 @@ impl<'de> serde::Deserialize<'de> for CompressedExistenceProof {
             Path,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -617,12 +617,12 @@ impl<'de> serde::Deserialize<'de> for CompressedExistenceProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -642,11 +642,11 @@ impl<'de> serde::Deserialize<'de> for CompressedExistenceProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CompressedExistenceProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.CompressedExistenceProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<CompressedExistenceProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<CompressedExistenceProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -683,7 +683,7 @@ impl<'de> serde::Deserialize<'de> for CompressedExistenceProof {
                                 return Err(serde::de::Error::duplicate_field("path"));
                             }
                             path__ = 
-                                Some(map.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                Some(map.next_value::<::alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
                         }
@@ -702,7 +702,7 @@ impl<'de> serde::Deserialize<'de> for CompressedExistenceProof {
 }
 impl serde::Serialize for CompressedNonExistenceProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -732,7 +732,7 @@ impl serde::Serialize for CompressedNonExistenceProof {
 }
 impl<'de> serde::Deserialize<'de> for CompressedNonExistenceProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -749,7 +749,7 @@ impl<'de> serde::Deserialize<'de> for CompressedNonExistenceProof {
             Right,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -758,12 +758,12 @@ impl<'de> serde::Deserialize<'de> for CompressedNonExistenceProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -782,11 +782,11 @@ impl<'de> serde::Deserialize<'de> for CompressedNonExistenceProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = CompressedNonExistenceProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.CompressedNonExistenceProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<CompressedNonExistenceProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<CompressedNonExistenceProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -829,7 +829,7 @@ impl<'de> serde::Deserialize<'de> for CompressedNonExistenceProof {
 }
 impl serde::Serialize for ExistenceProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -865,7 +865,7 @@ impl serde::Serialize for ExistenceProof {
 }
 impl<'de> serde::Deserialize<'de> for ExistenceProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -884,7 +884,7 @@ impl<'de> serde::Deserialize<'de> for ExistenceProof {
             Path,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -893,12 +893,12 @@ impl<'de> serde::Deserialize<'de> for ExistenceProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -918,11 +918,11 @@ impl<'de> serde::Deserialize<'de> for ExistenceProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ExistenceProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.ExistenceProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<ExistenceProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<ExistenceProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -975,7 +975,7 @@ impl<'de> serde::Deserialize<'de> for ExistenceProof {
 }
 impl serde::Serialize for HashOp {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -993,7 +993,7 @@ impl serde::Serialize for HashOp {
 }
 impl<'de> serde::Deserialize<'de> for HashOp {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1012,15 +1012,15 @@ impl<'de> serde::Deserialize<'de> for HashOp {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = HashOp;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                use std::convert::TryFrom;
+                use core::convert::TryFrom;
                 i32::try_from(v)
                     .ok()
                     .and_then(HashOp::from_i32)
@@ -1029,11 +1029,11 @@ impl<'de> serde::Deserialize<'de> for HashOp {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                use std::convert::TryFrom;
+                use core::convert::TryFrom;
                 i32::try_from(v)
                     .ok()
                     .and_then(HashOp::from_i32)
@@ -1042,7 +1042,7 @@ impl<'de> serde::Deserialize<'de> for HashOp {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1063,7 +1063,7 @@ impl<'de> serde::Deserialize<'de> for HashOp {
 }
 impl serde::Serialize for InnerOp {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1081,7 +1081,7 @@ impl serde::Serialize for InnerOp {
         let mut struct_ser = serializer.serialize_struct("cosmos.ics23.v1.InnerOp", len)?;
         if self.hash != 0 {
             let v = HashOp::from_i32(self.hash)
-                .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.hash)))?;
+                .ok_or_else(|| serde::ser::Error::custom(::alloc::format!("Invalid variant {}", self.hash)))?;
             struct_ser.serialize_field("hash", &v)?;
         }
         if !self.prefix.is_empty() {
@@ -1095,7 +1095,7 @@ impl serde::Serialize for InnerOp {
 }
 impl<'de> serde::Deserialize<'de> for InnerOp {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1112,7 +1112,7 @@ impl<'de> serde::Deserialize<'de> for InnerOp {
             Suffix,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1121,12 +1121,12 @@ impl<'de> serde::Deserialize<'de> for InnerOp {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1145,11 +1145,11 @@ impl<'de> serde::Deserialize<'de> for InnerOp {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InnerOp;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.InnerOp")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<InnerOp, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<InnerOp, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -1194,7 +1194,7 @@ impl<'de> serde::Deserialize<'de> for InnerOp {
 }
 impl serde::Serialize for InnerSpec {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1236,7 +1236,7 @@ impl serde::Serialize for InnerSpec {
         }
         if self.hash != 0 {
             let v = HashOp::from_i32(self.hash)
-                .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.hash)))?;
+                .ok_or_else(|| serde::ser::Error::custom(::alloc::format!("Invalid variant {}", self.hash)))?;
             struct_ser.serialize_field("hash", &v)?;
         }
         struct_ser.end()
@@ -1244,7 +1244,7 @@ impl serde::Serialize for InnerSpec {
 }
 impl<'de> serde::Deserialize<'de> for InnerSpec {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1272,7 +1272,7 @@ impl<'de> serde::Deserialize<'de> for InnerSpec {
             Hash,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1281,12 +1281,12 @@ impl<'de> serde::Deserialize<'de> for InnerSpec {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1308,11 +1308,11 @@ impl<'de> serde::Deserialize<'de> for InnerSpec {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = InnerSpec;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.InnerSpec")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<InnerSpec, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<InnerSpec, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -1329,7 +1329,7 @@ impl<'de> serde::Deserialize<'de> for InnerSpec {
                                 return Err(serde::de::Error::duplicate_field("childOrder"));
                             }
                             child_order__ = 
-                                Some(map.next_value::<Vec<::pbjson::private::NumberDeserialize<_>>>()?
+                                Some(map.next_value::<::alloc::vec::Vec<::pbjson::private::NumberDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
                         }
@@ -1388,7 +1388,7 @@ impl<'de> serde::Deserialize<'de> for InnerSpec {
 }
 impl serde::Serialize for LeafOp {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1412,22 +1412,22 @@ impl serde::Serialize for LeafOp {
         let mut struct_ser = serializer.serialize_struct("cosmos.ics23.v1.LeafOp", len)?;
         if self.hash != 0 {
             let v = HashOp::from_i32(self.hash)
-                .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.hash)))?;
+                .ok_or_else(|| serde::ser::Error::custom(::alloc::format!("Invalid variant {}", self.hash)))?;
             struct_ser.serialize_field("hash", &v)?;
         }
         if self.prehash_key != 0 {
             let v = HashOp::from_i32(self.prehash_key)
-                .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.prehash_key)))?;
+                .ok_or_else(|| serde::ser::Error::custom(::alloc::format!("Invalid variant {}", self.prehash_key)))?;
             struct_ser.serialize_field("prehashKey", &v)?;
         }
         if self.prehash_value != 0 {
             let v = HashOp::from_i32(self.prehash_value)
-                .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.prehash_value)))?;
+                .ok_or_else(|| serde::ser::Error::custom(::alloc::format!("Invalid variant {}", self.prehash_value)))?;
             struct_ser.serialize_field("prehashValue", &v)?;
         }
         if self.length != 0 {
             let v = LengthOp::from_i32(self.length)
-                .ok_or_else(|| serde::ser::Error::custom(format!("Invalid variant {}", self.length)))?;
+                .ok_or_else(|| serde::ser::Error::custom(::alloc::format!("Invalid variant {}", self.length)))?;
             struct_ser.serialize_field("length", &v)?;
         }
         if !self.prefix.is_empty() {
@@ -1438,7 +1438,7 @@ impl serde::Serialize for LeafOp {
 }
 impl<'de> serde::Deserialize<'de> for LeafOp {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1461,7 +1461,7 @@ impl<'de> serde::Deserialize<'de> for LeafOp {
             Prefix,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1470,12 +1470,12 @@ impl<'de> serde::Deserialize<'de> for LeafOp {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1496,11 +1496,11 @@ impl<'de> serde::Deserialize<'de> for LeafOp {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = LeafOp;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.LeafOp")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<LeafOp, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<LeafOp, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -1559,7 +1559,7 @@ impl<'de> serde::Deserialize<'de> for LeafOp {
 }
 impl serde::Serialize for LengthOp {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1579,7 +1579,7 @@ impl serde::Serialize for LengthOp {
 }
 impl<'de> serde::Deserialize<'de> for LengthOp {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1600,15 +1600,15 @@ impl<'de> serde::Deserialize<'de> for LengthOp {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = LengthOp;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(formatter, "expected one of: {:?}", &FIELDS)
             }
 
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            fn visit_i64<E>(self, v: i64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                use std::convert::TryFrom;
+                use core::convert::TryFrom;
                 i32::try_from(v)
                     .ok()
                     .and_then(LengthOp::from_i32)
@@ -1617,11 +1617,11 @@ impl<'de> serde::Deserialize<'de> for LengthOp {
                     })
             }
 
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                use std::convert::TryFrom;
+                use core::convert::TryFrom;
                 i32::try_from(v)
                     .ok()
                     .and_then(LengthOp::from_i32)
@@ -1630,7 +1630,7 @@ impl<'de> serde::Deserialize<'de> for LengthOp {
                     })
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> core::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -1653,7 +1653,7 @@ impl<'de> serde::Deserialize<'de> for LengthOp {
 }
 impl serde::Serialize for NonExistenceProof {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1683,7 +1683,7 @@ impl serde::Serialize for NonExistenceProof {
 }
 impl<'de> serde::Deserialize<'de> for NonExistenceProof {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1700,7 +1700,7 @@ impl<'de> serde::Deserialize<'de> for NonExistenceProof {
             Right,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1709,12 +1709,12 @@ impl<'de> serde::Deserialize<'de> for NonExistenceProof {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1733,11 +1733,11 @@ impl<'de> serde::Deserialize<'de> for NonExistenceProof {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = NonExistenceProof;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.NonExistenceProof")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<NonExistenceProof, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<NonExistenceProof, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -1780,7 +1780,7 @@ impl<'de> serde::Deserialize<'de> for NonExistenceProof {
 }
 impl serde::Serialize for ProofSpec {
     #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -1822,7 +1822,7 @@ impl serde::Serialize for ProofSpec {
 }
 impl<'de> serde::Deserialize<'de> for ProofSpec {
     #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -1848,7 +1848,7 @@ impl<'de> serde::Deserialize<'de> for ProofSpec {
             PrehashKeyBeforeComparison,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<GeneratedField, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
@@ -1857,12 +1857,12 @@ impl<'de> serde::Deserialize<'de> for ProofSpec {
                 impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
                     type Value = GeneratedField;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                         write!(formatter, "expected one of: {:?}", &FIELDS)
                     }
 
                     #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    fn visit_str<E>(self, value: &str) -> core::result::Result<GeneratedField, E>
                     where
                         E: serde::de::Error,
                     {
@@ -1883,11 +1883,11 @@ impl<'de> serde::Deserialize<'de> for ProofSpec {
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
             type Value = ProofSpec;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 formatter.write_str("struct cosmos.ics23.v1.ProofSpec")
             }
 
-            fn visit_map<V>(self, mut map: V) -> std::result::Result<ProofSpec, V::Error>
+            fn visit_map<V>(self, mut map: V) -> core::result::Result<ProofSpec, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {


### PR DESCRIPTION
Closes: #156

## Background
This PR addresses the `no_std` compatibility issue with `serde` feature in `ibc-rs`. This is caused by the recent [implementation of ProtoJSON serialization and deserialization](https://github.com/cosmos/ics23/pull/146) for the `ics23` Protobuf definitions using `pbjson`, and then [re-exporting the ics23 type](https://github.com/cosmos/ibc-proto-rs/pull/92) in `ibc-proto-rs`. Some of our users by then (starting from IBC-rs v0.41.0) are experiencing [compilation errors](https://github.com/cosmos/ibc-rs/issues/741).

To meet [this immediate need](https://github.com/cosmos/ibc-proto-rs/issues/98#issuecomment-1653311451) and the lack of activity in the `pbjson` crate for months, we have taken the initiative to feature `no_std` support in the `informalsystems-pbjson` crate and have it published.

Before finalizing this change, I’d like to cross-check with @hdevalence to ensure this addition is in line with their systems too and maintain the expected behavior.

**Subsequent PR in `ibc-proto-rs`**: https://github.com/cosmos/ibc-proto-rs/pull/118
**Subsequent PR in `ibc-rs`**: https://github.com/cosmos/ibc-rs/pull/790