### PR TITLE
chore: add prefix to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,21 +6,29 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/js"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
 
   # Maintain dependencies for Composer
   - package-ecosystem: "gomod"
     directory: "/go"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
 
   # Maintain dependencies for Composer
   - package-ecosystem: "cargo"
     directory: "/rust"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
To prevent errors like [this](https://github.com/cosmos/ics23/actions/runs/5969598129/job/16195719847?pr=166).