### PR TITLE
chore: avoid cloning and use `.map`/`.entry` in Rust code

### DIFF
--- a/rust/src/compress.rs
+++ b/rust/src/compress.rs
@@ -30,42 +30,43 @@ pub fn decompress(proof: &ics23::CommitmentProof) -> Result<ics23::CommitmentPro
 }
 
 pub fn compress_batch(proof: &ics23::BatchProof) -> Result<ics23::CommitmentProof> {
-    let mut centries = Vec::new();
     let mut lookup = Vec::new();
     let mut registry = HashMap::new();
 
-    for entry in &proof.entries {
-        let centry = match &entry.proof {
+    let centries = proof
+        .entries
+        .iter()
+        .map(|entry| match &entry.proof {
             Some(ics23::batch_entry::Proof::Exist(ex)) => {
                 let exist = compress_exist(ex, &mut lookup, &mut registry)?;
-                ics23::CompressedBatchEntry {
+                Ok(ics23::CompressedBatchEntry {
                     proof: Some(ics23::compressed_batch_entry::Proof::Exist(exist)),
-                }
+                })
             }
             Some(ics23::batch_entry::Proof::Nonexist(non)) => {
                 let left = non
                     .left
-                    .clone()
-                    .map(|l| compress_exist(&l, &mut lookup, &mut registry))
+                    .as_ref()
+                    .map(|l| compress_exist(l, &mut lookup, &mut registry))
                     .transpose()?;
                 let right = non
                     .right
-                    .clone()
-                    .map(|r| compress_exist(&r, &mut lookup, &mut registry))
+                    .as_ref()
+                    .map(|r| compress_exist(r, &mut lookup, &mut registry))
                     .transpose()?;
                 let nonexist = ics23::CompressedNonExistenceProof {
                     key: non.key.clone(),
                     left,
                     right,
                 };
-                ics23::CompressedBatchEntry {
+                Ok(ics23::CompressedBatchEntry {
                     proof: Some(ics23::compressed_batch_entry::Proof::Nonexist(nonexist)),
-                }
+                })
             }
-            None => ics23::CompressedBatchEntry { proof: None },
-        };
-        centries.push(centry);
-    }
+            None => Ok(ics23::CompressedBatchEntry { proof: None }),
+        })
+        .collect::<Result<_>>()?;
+
     Ok(ics23::CommitmentProof {
         proof: Some(ics23::commitment_proof::Proof::Compressed(
             ics23::CompressedBatchProof {
@@ -85,19 +86,15 @@ pub fn compress_exist(
         .path
         .iter()
         .map(|x| {
-            let mut buf = Vec::new();
-            x.encode(&mut buf)
-                .map_err(|e: prost::EncodeError| anyhow::anyhow!(e))?;
-
-            if let Some(&idx) = registry.get(buf.as_slice()) {
-                return Ok(idx);
-            };
-            let idx = lookup.len() as i32;
-            lookup.push(x.to_owned());
-            registry.insert(buf, idx);
+            let buf = x.encode_to_vec();
+            let idx = *registry.entry(buf).or_insert_with(|| {
+                let idx = lookup.len() as i32;
+                lookup.push(x.to_owned());
+                idx
+            });
             Ok(idx)
         })
-        .collect::<Result<Vec<i32>>>()?;
+        .collect::<Result<_>>()?;
 
     Ok(ics23::CompressedExistenceProof {
         key: exist.key.clone(),
@@ -112,30 +109,28 @@ pub fn decompress_batch(proof: &ics23::CompressedBatchProof) -> Result<ics23::Co
     let entries = proof
         .entries
         .iter()
-        .map(|cent| -> Result<ics23::BatchEntry> {
-            match &cent.proof {
-                Some(ics23::compressed_batch_entry::Proof::Exist(ex)) => {
-                    let exist = decompress_exist(ex, lookup);
-                    Ok(ics23::BatchEntry {
-                        proof: Some(ics23::batch_entry::Proof::Exist(exist)),
-                    })
-                }
-                Some(ics23::compressed_batch_entry::Proof::Nonexist(non)) => {
-                    let left = non.left.clone().map(|l| decompress_exist(&l, lookup));
-                    let right = non.right.clone().map(|r| decompress_exist(&r, lookup));
-                    let nonexist = ics23::NonExistenceProof {
-                        key: non.key.clone(),
-                        left,
-                        right,
-                    };
-                    Ok(ics23::BatchEntry {
-                        proof: Some(ics23::batch_entry::Proof::Nonexist(nonexist)),
-                    })
-                }
-                None => Ok(ics23::BatchEntry { proof: None }),
+        .map(|cent| match &cent.proof {
+            Some(ics23::compressed_batch_entry::Proof::Exist(ex)) => {
+                let exist = decompress_exist(ex, lookup);
+                Ok(ics23::BatchEntry {
+                    proof: Some(ics23::batch_entry::Proof::Exist(exist)),
+                })
             }
+            Some(ics23::compressed_batch_entry::Proof::Nonexist(non)) => {
+                let left = non.left.as_ref().map(|l| decompress_exist(l, lookup));
+                let right = non.right.as_ref().map(|r| decompress_exist(r, lookup));
+                let nonexist = ics23::NonExistenceProof {
+                    key: non.key.clone(),
+                    left,
+                    right,
+                };
+                Ok(ics23::BatchEntry {
+                    proof: Some(ics23::batch_entry::Proof::Nonexist(nonexist)),
+                })
+            }
+            None => Ok(ics23::BatchEntry { proof: None }),
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Result<_>>()?;
 
     Ok(ics23::CommitmentProof {
         proof: Some(ics23::commitment_proof::Proof::Batch(ics23::BatchProof {


### PR DESCRIPTION
There's no functional changes, just some code cleanup.