### PR TITLE
fix(go): bullet-proof against nil dereferences + more fuzzers

### DIFF
--- a/go/ics23.go
+++ b/go/ics23.go
@@ -132,6 +132,10 @@ func CombineProofs(proofs []*CommitmentProof) (*CommitmentProof, error) {
 }
 
 func getExistProofForKey(proof *CommitmentProof, key []byte) *ExistenceProof {
+	if proof == nil {
+		return nil
+	}
+
 	switch p := proof.Proof.(type) {
 	case *CommitmentProof_Exist:
 		ep := p.Exist

--- a/go/ops.go
+++ b/go/ops.go
@@ -94,7 +94,13 @@ func (op *InnerOp) Apply(child []byte) ([]byte, error) {
 
 // CheckAgainstSpec will verify the LeafOp is in the format defined in spec
 func (op *LeafOp) CheckAgainstSpec(spec *ProofSpec) error {
+	if spec == nil {
+		return errors.New("op and spec must be non-nil")
+	}
 	lspec := spec.LeafSpec
+	if lspec == nil {
+		return errors.New("spec.LeafSpec must be non-nil")
+	}
 
 	if validateSpec(spec) {
 		err := validateIavlOps(op, 0)
@@ -123,6 +129,16 @@ func (op *LeafOp) CheckAgainstSpec(spec *ProofSpec) error {
 
 // CheckAgainstSpec will verify the InnerOp is in the format defined in spec
 func (op *InnerOp) CheckAgainstSpec(spec *ProofSpec, b int) error {
+	if spec == nil {
+		return errors.New("op and spec must be both non-nil")
+	}
+	if spec.InnerSpec == nil {
+		return errors.New("spec.InnerSpec must be non-nil")
+	}
+	if spec.LeafSpec == nil {
+		return errors.New("spec.LeafSpec must be non-nil")
+	}
+
 	if op.Hash != spec.InnerSpec.Hash {
 		return fmt.Errorf("unexpected HashOp: %d", op.Hash)
 	}
@@ -144,6 +160,10 @@ func (op *InnerOp) CheckAgainstSpec(spec *ProofSpec, b int) error {
 	maxLeftChildBytes := (len(spec.InnerSpec.ChildOrder) - 1) * int(spec.InnerSpec.ChildSize)
 	if len(op.Prefix) > int(spec.InnerSpec.MaxPrefixLength)+maxLeftChildBytes {
 		return fmt.Errorf("innerOp prefix too long (%d)", len(op.Prefix))
+	}
+
+	if spec.InnerSpec.ChildSize <= 0 {
+		return errors.New("spec.InnerSpec.ChildSize must be >= 1")
 	}
 
 	// ensures soundness, with suffix having to be of correct length

--- a/go/proof_data_test.go
+++ b/go/proof_data_test.go
@@ -13,18 +13,18 @@ type ExistenceProofTestStruct struct {
 	Expected []byte
 }
 
-func ExistenceProofTestData(t *testing.T) map[string]ExistenceProofTestStruct {
-	t.Helper()
+func ExistenceProofTestData(tb testing.TB) map[string]ExistenceProofTestStruct {
+	tb.Helper()
 	fname := filepath.Join("..", "testdata", "TestExistenceProofData.json")
 	ffile, err := os.Open(fname)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	var cases map[string]ExistenceProofTestStruct
 	jsonDecoder := json.NewDecoder(ffile)
 	err = jsonDecoder.Decode(&cases)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	return cases
 }
@@ -35,18 +35,18 @@ type CheckLeafTestStruct struct {
 	IsErr bool
 }
 
-func CheckLeafTestData(t *testing.T) map[string]CheckLeafTestStruct {
-	t.Helper()
+func CheckLeafTestData(tb testing.TB) map[string]CheckLeafTestStruct {
+	tb.Helper()
 	fname := filepath.Join("..", "testdata", "TestCheckLeafData.json")
 	ffile, err := os.Open(fname)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	var cases map[string]CheckLeafTestStruct
 	jsonDecoder := json.NewDecoder(ffile)
 	err = jsonDecoder.Decode(&cases)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	return cases
 }
@@ -57,18 +57,18 @@ type CheckAgainstSpecTestStruct struct {
 	IsErr bool
 }
 
-func CheckAgainstSpecTestData(t *testing.T) map[string]CheckAgainstSpecTestStruct {
-	t.Helper()
+func CheckAgainstSpecTestData(tb testing.TB) map[string]CheckAgainstSpecTestStruct {
+	tb.Helper()
 	fname := filepath.Join("..", "testdata", "TestCheckAgainstSpecData.json")
 	ffile, err := os.Open(fname)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	var cases map[string]CheckAgainstSpecTestStruct
 	jsonDecoder := json.NewDecoder(ffile)
 	err = jsonDecoder.Decode(&cases)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	return cases
 }

--- a/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/09bebc2fc8d0a79b
+++ b/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/09bebc2fc8d0a79b
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Proof\":{\"leAf\":{\"prehAsh_vAlue\":1,\"length\":1,\"prefiX\":\"AA00\"},\"pAth\":[{\"hAsh\":1}]},\"SpeC\":{\"leAf_speC\":{\"prehAsh_vAlue\":1,\"length\":1,\"prefiX\":\"AA00\"},\"inner_speC\":{\"hAsh\":1}}}")

--- a/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/19e35d361fe85847
+++ b/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/19e35d361fe85847
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Proof\":{\"leAf\":{},\"pAth\":[{}]},\"SpeC\":{\"leAf_speC\":{}}}")

--- a/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/1f84363823f5c624
+++ b/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/1f84363823f5c624
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Proof\":{\"leAf\":{}},\"SpeC\":{}}")

--- a/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/a9ba9cba7c7724a0
+++ b/go/testdata/fuzz/FuzzExistenceProofCheckAgainstSpec/a9ba9cba7c7724a0
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Proof\":{\"leAf\":{}}}")

--- a/go/testdata/fuzz/FuzzVerifyMembership/8093511184ad3e25
+++ b/go/testdata/fuzz/FuzzVerifyMembership/8093511184ad3e25
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{}")

--- a/go/testdata/fuzz/FuzzVerifyMembership/99dd1125ca292163
+++ b/go/testdata/fuzz/FuzzVerifyMembership/99dd1125ca292163
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"Ref\":{}}")

--- a/go/vectors_data_test.go
+++ b/go/vectors_data_test.go
@@ -165,42 +165,42 @@ func DecompressBatchVectorsTestData(t *testing.T) map[string]*CommitmentProof {
 	}
 }
 
-func LoadFile(t *testing.T, dir string, filename string) (*CommitmentProof, *RefData) {
-	t.Helper()
+func LoadFile(tb testing.TB, dir string, filename string) (*CommitmentProof, *RefData) {
+	tb.Helper()
 	// load the file into a json struct
 	name := filepath.Join(dir, filename)
 	bz, err := os.ReadFile(name)
 	if err != nil {
-		t.Fatalf("Read file: %+v", err)
+		tb.Fatalf("Read file: %+v", err)
 	}
 	var data TestVector
 	err = json.Unmarshal(bz, &data)
 	if err != nil {
-		t.Fatalf("Unmarshal json: %+v", err)
+		tb.Fatalf("Unmarshal json: %+v", err)
 	}
 	// parse the protobuf object
 	var proof CommitmentProof
-	err = proof.Unmarshal(mustHex(t, data.Proof))
+	err = proof.Unmarshal(mustHex(tb, data.Proof))
 	if err != nil {
-		t.Fatalf("Unmarshal protobuf: %+v", err)
+		tb.Fatalf("Unmarshal protobuf: %+v", err)
 	}
 	var ref RefData
-	ref.RootHash = CommitmentRoot(mustHex(t, data.RootHash))
-	ref.Key = mustHex(t, data.Key)
+	ref.RootHash = CommitmentRoot(mustHex(tb, data.RootHash))
+	ref.Key = mustHex(tb, data.Key)
 	if data.Value != "" {
-		ref.Value = mustHex(t, data.Value)
+		ref.Value = mustHex(tb, data.Value)
 	}
 	return &proof, &ref
 }
 
-func mustHex(t *testing.T, data string) []byte {
-	t.Helper()
+func mustHex(tb testing.TB, data string) []byte {
+	tb.Helper()
 	if data == "" {
 		return nil
 	}
 	res, err := hex.DecodeString(data)
 	if err != nil {
-		t.Fatalf("decoding hex: %v", err)
+		tb.Fatalf("decoding hex: %v", err)
 	}
 	return res
 }


### PR DESCRIPTION
This change fixes a bunch of issues identified by Orijtech Inc's audit
of ics23 which is a critical cosmos-sdk dependency and as per reports
about the Dragonberry & Elderberry vulnerability reports, this package
was put back on our radar to further audit and voila that uncovered
some issues, some of which have beenfixed in this change. While here
also added more fuzzers. To ensure that the fuzzers can run alright,
added -short to any invocations of "go test".

Fixes #241
Fixes #242
Fixes #243