### PR TITLE
fix: Fix verification of proofs for specs with more than 2 children per node (in Rust implementation)

### DIFF
--- a/rust/src/cosmos.ics23.v1.rs
+++ b/rust/src/cosmos.ics23.v1.rs
@@ -171,7 +171,7 @@ pub struct ProofSpec {
 pub struct InnerSpec {
     /// Child order is the ordering of the children node, must count from 0
     /// iavl tree is \[0, 1\] (left then right)
-    /// merk is \[0, 2, 1\] (left, right, here)
+    /// merk is \[0, 1, 2\] (left, here, right)
     #[prost(int32, repeated, tag = "1")]
     pub child_order: ::prost::alloc::vec::Vec<i32>,
     #[prost(int32, tag = "2")]

--- a/rust/src/verify.rs
+++ b/rust/src/verify.rs
@@ -230,7 +230,7 @@ fn ensure_right_most(spec: &ics23::InnerSpec, path: &[ics23::InnerOp]) -> Result
     // ensure every step has a prefix and suffix defined to be rightmost, unless it is a placeholder node
     for step in path {
         if !has_padding(step, &pad) && !right_branches_are_empty(spec, step)? {
-            bail!("step not leftmost")
+            bail!("step not rightmost")
         }
     }
     Ok(())
@@ -344,7 +344,7 @@ fn right_branches_are_empty(spec: &ics23::InnerSpec, op: &ics23::InnerOp) -> Res
     if right_branches == 0 {
         return Ok(false);
     }
-    if op.suffix.len() != spec.child_size as usize {
+    if op.suffix.len() != right_branches * spec.child_size as usize {
         return Ok(false);
     }
     for i in 0..right_branches {


### PR DESCRIPTION
This PR fixes the Rust `right_branches_are_empty` implementation, specifically for specs which have more than 2 children per node (e.g. Merk).