### PR TITLE
fix: a Rust linter warning

### DIFF
--- a/rust/no-std-check/src/lib.rs
+++ b/rust/no-std-check/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 // Import the crates that we want to check if they are fully no-std compliance
 
-use ics23;
+use ics23::*;
 
 use core::panic::PanicInfo;
 


### PR DESCRIPTION
The `use ics23;` statement in the no-std check crate triggers the following linter warning:

```plain
warning: this import is redundant
 --> no-std-check/src/lib.rs:9:1
  |
9 | use ics23;
  | ^^^^^^^^^^ help: remove it entirely
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
  = note: `#[warn(clippy::single_component_path_imports)]` on by default
```

This can be fixed by changing it to `use ics23::*;`.