### PR TITLE
chore: add name for protobuf break workflow

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -22,6 +22,7 @@ jobs:
 
   break-check:
     runs-on: ubuntu-latest
+    name: Protobuf break check
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.43.0


### PR DESCRIPTION
Looking into #376, I was unable to add the buf breaking check as required, I believe due to a missing name (which I have added). I'm unsure if it'll be problematic that this CI won't be run on every pr?